### PR TITLE
Speed-up downloads

### DIFF
--- a/terracatalogueclient/client.py
+++ b/terracatalogueclient/client.py
@@ -351,7 +351,7 @@ class Catalogue:
         with requests.get(product_file.href, stream=True, auth=self._auth, allow_redirects=False, headers=_DEFAULT_REQUEST_HEADERS) as r:
             r.raise_for_status()
             with open(out_path, 'wb') as f:
-                for chunk in r.iter_content():
+                for chunk in r.iter_content(chunk_size=8192):
                     if chunk:
                         f.write(chunk)
 


### PR DESCRIPTION
Speed up downloads by setting chunk size when downloading files to avoid CPU bottleneck.